### PR TITLE
Bugfix: Compile error due to defaultClassName still beeing escaped

### DIFF
--- a/server/src/grammer/terms/preprocessingsnippets.ts
+++ b/server/src/grammer/terms/preprocessingsnippets.ts
@@ -157,7 +157,7 @@ ${settingsContext}
 function preprocessingFooter(): String{
 	let generatedFooter: String = `
 public static void main(String[] args) {
-PApplet.main(\\\"${defaultClassName}\\\");
+PApplet.main(${defaultClassName});
 }`
 	return generatedFooter
 }


### PR DESCRIPTION
Created when using fs.writefilesync(). Unescape the defaultClassName