### PR TITLE
Feature/make suitable for windows

### DIFF
--- a/server/src/diagnostics.ts
+++ b/server/src/diagnostics.ts
@@ -96,11 +96,17 @@ export function cookCompilationDiagnostics(processedText: string, pwd: String){
 			tempSplit.forEach(function(line:String, index: number){
 				if(line.includes(`${pwd}`)){
 					let innerSplit = line.split(":")
+					
+					//Correct split index (OS depentend)
+					let splitIndex;
+					if (process.platform === 'win32') splitIndex = 2
+					else splitIndex = 1
+
 					// Handling line number based on current Behaviour - since preprocessing is done
 					if(preProcessingClass.defaultBehaviourEnable){
-						errorNodeLine[errorNodeCount] = +innerSplit[1] - pStandards.reduceLineDefaultBehaviour
+						errorNodeLine[errorNodeCount] = +innerSplit[splitIndex] - pStandards.reduceLineDefaultBehaviour
 					} else if(preProcessingClass.methodBehaviourEnable){
-						errorNodeLine[errorNodeCount] = +innerSplit[1] - pStandards.reduceLineMethodBehaviour
+						errorNodeLine[errorNodeCount] = +innerSplit[splitIndex] - pStandards.reduceLineMethodBehaviour
 					}
 					let localIndex = index + 1
 					errorNodeReasons[errorNodeCount] = line.split("error:")[1]

--- a/server/src/parser.ts
+++ b/server/src/parser.ts
@@ -52,10 +52,14 @@ export function parseAST(processedText: string, textDocument: TextDocument) {
 		log.writeLog(`[[ERR]] - Error in Java File Compilation`)
 	}
 
-	// Wrote methods to handle Error in the Error Stream
-	// diagnostics.cookDiagnosticsReport(processedText)
-	diagnostics.cookCompilationDiagnostics(processedText, `${__dirname}/compile/${pStandards.defaultClassName}.java`)
-
+	//Correct path for different OS's
+	let pwd
+	if (process.platform === 'win32') {
+		pwd =`${__dirname}\\compile\\${pStandards.defaultClassName}.java`
+	}else {
+		pwd = `${__dirname}/compile/${pStandards.defaultClassName}.java`
+	}
+	diagnostics.cookCompilationDiagnostics(processedText, pwd)
 
 	log.writeLog("Parse Tree construction Successfully")
 }


### PR DESCRIPTION
LS4P should now work on Windows, updated the following:

"Run Processing Sketch" Task not executing a processing sketch
- Make file copying OS independent using fs.copyFileSync()
- OS dependent class path parameter for java execution. Windows cp should end with a ";' instead of ":"
- Set workdir directly in ChildProcess.exe trough cwd option. The execution of a cd command in windows wasn't changing the directory

No error messages were displayed in the client
-  OS dependent pwd path for [cookCompilationDiagnostics](https://github.com/Efratror/LS4P/blob/e4159faff29f08c77800ec8c0f34958674b655ff/server/src/diagnostics.ts#L77). Lines didn't include the path due to "\\" and "/" difference. 
- OS dependent split index for line number reference. Windows uses colons in it's path offsetting the line number by one in the [innersplit array](https://github.com/Efratror/LS4P/blob/e4159faff29f08c77800ec8c0f34958674b655ff/server/src/diagnostics.ts#L98)