### PR TITLE
Feauture/multi tab support

### DIFF
--- a/client/src/extension.ts
+++ b/client/src/extension.ts
@@ -32,7 +32,7 @@ export function activate(context: vscode.ExtensionContext) {
 	let clientOptions: LanguageClientOptions = {
 		documentSelector: [{ scheme: 'file', language: 'Processing' }],
 		synchronize: {
-			fileEvents: vscode.workspace.createFileSystemWatcher('**/.clientrc')
+			fileEvents: vscode.workspace.createFileSystemWatcher('**/*')
 		}
 	};
 

--- a/server/src/definition.ts
+++ b/server/src/definition.ts
@@ -8,6 +8,7 @@ import { Definition } from 'vscode-languageserver'
 import * as parser from './parser'
 import * as javaSpecific from './grammer/terms/javaspecific'
 import { ClassDeclarationContext, VariableDeclaratorIdContext, MethodDeclarationContext } from 'java-ast/dist/parser/JavaParser';
+import * as sketch from './sketch'
 
 let currentTempAST: [ParseTree][] = new Array();
 let _currentTempCounter = -1
@@ -41,15 +42,15 @@ export function scheduleLookUpDefinition(receivedUri: string,lineNumber: number,
 	parser.tokenArray.forEach(function(token){
 		if(token[1] instanceof ClassDeclarationContext){
 			if(!(javaSpecific.TOP_LEVEL_KEYWORDS.indexOf(token[0].text) > -1)){
-				foundDeclaration[_foundDeclarationCount] = [`class`, token[0].text, token[0].payload._line-(adjustOffset+1), token[0].payload._charPositionInLine]
+				foundDeclaration[_foundDeclarationCount] = [`class`, token[0].text, token[0].payload._line-(adjustOffset), token[0].payload._charPositionInLine]
 				_foundDeclarationCount +=1
 			}
 		} else if(token[1] instanceof VariableDeclaratorIdContext){
-			foundDeclaration[_foundDeclarationCount] = [`var`, token[0].text, token[0].payload._line-(adjustOffset+1), token[0].payload._charPositionInLine]
+			foundDeclaration[_foundDeclarationCount] = [`var`, token[0].text, token[0].payload._line-(adjustOffset), token[0].payload._charPositionInLine]
 			_foundDeclarationCount +=1
 		} else if(token[1] instanceof MethodDeclarationContext){
 			// TODO: conflict in `_charPositionInLine` due to addition of `public` infront during preprocessing -> tabs should also be handled
-			foundDeclaration[_foundDeclarationCount] = [`method`, token[0].text, token[0].payload._line-(adjustOffset+1), token[0].payload._charPositionInLine - 3]
+			foundDeclaration[_foundDeclarationCount] = [`method`, token[0].text, token[0].payload._line-(adjustOffset), token[0].payload._charPositionInLine - 3]
 			_foundDeclarationCount +=1
 		}
 	})
@@ -61,15 +62,23 @@ export function scheduleLookUpDefinition(receivedUri: string,lineNumber: number,
 		if((word[1] <= charNumber) && (charNumber <= word[2])){
 			foundDeclaration.forEach(function(delarationName){
 				if(word[0] == delarationName[1]){
+					let lineNumberJavaFile = delarationName[2];
+					let difLine : number = 0;
+					let docUri : string = '';
+					if (sketch.transformDict.get(lineNumberJavaFile)) {
+						difLine = sketch.transformDict.get(lineNumberJavaFile)!.lineNumber
+						let docName =  sketch.transformDict.get(lineNumberJavaFile)!.fileName
+						docUri = sketch.uri+docName
+					} 
 					finalDefinition = {
-						uri: receivedUri,
+						uri: docUri,
 						range:{
 							start: {
-								line: delarationName[2],
+								line: difLine-1,
 								character: delarationName[3]
 							},
 							end: {
-								line: delarationName[2],
+								line: difLine-1,
 								character: delarationName[3]+word[0].length
 							}
 						}

--- a/server/src/diagnostics.ts
+++ b/server/src/diagnostics.ts
@@ -12,6 +12,7 @@ import * as parser from './parser'
 import * as preProcessingClass from './preprocessing'
 import * as pStandards from './grammer/terms/preprocessingsnippets'
 import * as log from './scripts/syslogs'
+import * as sketch from './sketch';
 
 const fs = require('fs');
 
@@ -27,12 +28,30 @@ let totalErrorCount = 0
 // Diagnostics report based on Error Node
 export async function checkForRealtimeDiagnostics(processedTextDocument: TextDocument): Promise<void> {
 	let settings = await server.getDocumentSettings(processedTextDocument.uri);
-	let processedText = processedTextDocument.getText()
 	let problems = 0;
-	let diagnostics: Diagnostic[] = []
-	let m: RegExpMatchArray | null;
-	errorNodeLine.forEach(function(errorLine, index){
-		if(problems < settings.maxNumberOfProblems){
+	let errorLine : number = 0
+	let errorDocName : string = ''
+	let errorDocUri : string = ''
+
+	//Create a  diaggnostics per tab
+	let fileDiagnostics = new Map<string,  Diagnostic[]>()
+	sketch.contents.forEach(function(value, key : string){
+		let emptyDiag : Diagnostic[] = []
+
+		fileDiagnostics.set(key, emptyDiag)
+	})
+	
+	errorNodeLine.forEach(function(javaErrorLine, index){
+		// Get the real error line number
+		if (sketch.transformDict.get(javaErrorLine)) {
+			errorLine = sketch.transformDict.get(javaErrorLine)!.lineNumber
+			errorDocName =  sketch.transformDict.get(javaErrorLine)!.fileName
+			errorDocUri = sketch.uri+errorDocName
+		}
+
+		let diagnostics = fileDiagnostics.get(errorDocName);
+
+		if(problems < settings.maxNumberOfProblems && diagnostics){
 			problems++;
 			let diagnostic: Diagnostic = {
 				severity: DiagnosticSeverity.Error,
@@ -54,7 +73,7 @@ export async function checkForRealtimeDiagnostics(processedTextDocument: TextDoc
 				diagnostic.relatedInformation = [
 					{
 						location: {
-							uri: processedTextDocument.uri,
+							uri: errorDocUri,
 							range: Object.assign({}, diagnostic.range)
 						},
 						message: `${errorNodeReasons[index]}`
@@ -62,9 +81,16 @@ export async function checkForRealtimeDiagnostics(processedTextDocument: TextDoc
 				];
 			}
 			diagnostics.push(diagnostic);
+			fileDiagnostics.set(errorDocName, diagnostics)
 		}
 	})
-	server.connection.sendDiagnostics({ uri: processedTextDocument.uri, diagnostics });
+
+	//Send all diagnastics reports to the client
+	for (let [file, diagnostics] of fileDiagnostics)  {
+		let fileUri = sketch.uri+file
+	server.connection.sendDiagnostics({uri: fileUri, diagnostics})
+	}
+	
 }
 
 function setErrorNodeBackToDefault(){

--- a/server/src/references.ts
+++ b/server/src/references.ts
@@ -5,6 +5,7 @@ import * as pstandard from './grammer/terms/preprocessingsnippets'
 import { parse } from 'java-ast'
 import { ParseTree } from 'antlr4ts/tree/ParseTree'
 import { tokenArray } from './parser';
+import * as sketch from './sketch'
 
 let currentTempAST: [ParseTree][] = new Array();
 let _currentTempCounter = -1
@@ -48,15 +49,23 @@ export function scheduleLookUpReference(_referenceParams: ReferenceParams): Loca
 		if((word[1] <= _referenceParams.position.character) && (_referenceParams.position.character <= word[2])){
 			tokenArray.forEach(function(token){
 				if(token[0].text == word[0]){
+					let lineNumberJavaFile = token[0].payload._line-adjustOffset
+					let difLine : number = 0;
+					let docUri : string = '';
+					if (sketch.transformDict.get(lineNumberJavaFile)) {
+						difLine = sketch.transformDict.get(lineNumberJavaFile)!.lineNumber
+						let docName =  sketch.transformDict.get(lineNumberJavaFile)!.fileName
+						docUri = sketch.uri+docName
+					}
 					multipleTokenOccurenceLocations[_multipleTokenCount] = {
-						uri: _referenceParams.textDocument.uri,
+						uri: docUri,
 						range: {
 							start: {
-								line: token[0].payload._line-(adjustOffset+1),
+								line: difLine-1,
 								character: token[0].payload._charPositionInLine
 							},
 							end: {
-								line: token[0].payload._line-(adjustOffset+1),
+								line: difLine-1,
 								character: token[0].payload._charPositionInLine + word[0].length
 							}
 						}

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -14,7 +14,8 @@ import {
 	Location,
 	ReferenceParams,
 	RenameParams,
-	WorkspaceEdit
+	WorkspaceEdit,
+	FileChangeType
 } from 'vscode-languageserver';
 
 import { interval, Observable, of, Subject } from 'rxjs';
@@ -28,6 +29,7 @@ import * as log from './scripts/syslogs'
 import * as definition from './definition'
 import * as lens from './lens'
 import * as reference from './references'
+import * as sketch from './sketch';
 
 export let connection = createConnection(ProposedFeatures.all);
 
@@ -158,7 +160,22 @@ function sleep(ms: number) {
 }
 
 connection.onDidChangeWatchedFiles(_change => {
-	connection.console.log('We received an file change event');
+	console.log('We received an workspace file change event');
+
+	for (let i = 0; i < _change.changes.length; i++) {
+		const change = _change.changes[i];
+		switch (change.type) {
+		  case FileChangeType.Created:
+			sketch.addTab(change.uri)
+			break;
+		  case FileChangeType.Deleted:
+			sketch.removeTab(change.uri)
+			break;
+		  default:
+			// do nothing
+			break;
+		}
+	}
 });
 
 // Implementation for `goto definition` goes here

--- a/server/src/sketch.ts
+++ b/server/src/sketch.ts
@@ -54,6 +54,25 @@ export function createSketch(textDocument: lsp.TextDocument) {
 	created = true
 }
 
+export function addTab(uri: string) {
+	if (created) {
+		let fileName = pathM.basename(uri)
+		if (fileName.endsWith('.pde')) {
+			let tabContents = fs.readdirSync(path+fileName, 'utf-8')
+			contents.set(fileName, tabContents)
+		}
+	}
+}
+
+export function removeTab(uri: string) {
+	if (created) {
+		let fileName = pathM.basename(uri)
+		if (fileName.endsWith('.pde') && contents.has(fileName)) {
+			contents.delete(fileName)
+		}
+	}
+}
+
 function getPathFromUri(uri : string) : string {
 	let path = uri.replace('file:///', '')
 	path =  path.replace('%3A', ':')

--- a/server/src/sketch.ts
+++ b/server/src/sketch.ts
@@ -1,0 +1,69 @@
+import * as lsp from 'vscode-languageserver'
+
+const fs = require('fs')
+const pathM = require('path')
+
+
+export let path : string = ''
+export let uri : string = ''
+export let name : string = '';
+export let contents  = new Map<string, string>()
+export let created = false;
+
+export interface IOriginalTab {
+	lineNumber: number;	//Line number in the orgininal file
+	fileName: string;	//Name of the original file
+}
+export let transformDict = new Map<number, IOriginalTab>()
+
+
+export function createSketch(textDocument: lsp.TextDocument) {
+	
+	uri = pathM.dirname(textDocument.uri)+'/'
+	path = getPathFromUri(uri)
+	name = pathM.basename(path)
+
+	try {
+		let mainFileName = name+'.pde'
+		let mainFileContents = fs.readFileSync(path+mainFileName, 'utf-8')
+
+		contents.set(mainFileName, mainFileContents)
+	}
+	catch (e) {
+		console.log("Some thing went wrong while loading the main file")
+		console.log(e)
+		return
+	}
+
+	try{
+		let fileNames = fs.readdirSync(path)
+		fileNames.forEach((fileName : string) =>{
+			if (fileName.endsWith('.pde') && !fileName.includes(name)){
+				let tabContents = fs.readFileSync(path+fileName, 'utf-8')
+				contents.set(fileName, tabContents)
+			}
+		});
+	}
+	catch(e) {
+		console.log("Some thing went wrong while loading the other files")
+		console.log(e)
+		return
+	}
+
+	
+	created = true
+}
+
+function getPathFromUri(uri : string) : string {
+	let path = uri.replace('file:///', '')
+	path =  path.replace('%3A', ':')
+
+	return path
+}
+
+export function getUriFromPath(path : string) : string  {
+	let tempUri = path.replace(':', '%3A')
+	tempUri = 'file:///'+ + tempUri
+
+	return tempUri
+}


### PR DESCRIPTION
Addes multi tab support like in the processing IDE.

on the first preprocessing cycle there is a "sketch" created. This sketch keeps track of all the tabs(.pde files) in the workspace in a contents map. When doing the preprocessing a transformation dictionary is updated. This dict knows which line in the java file came from which tab and the line number associated with it. This so you can convert from the java file to the specific tab.

#### Changes:
- preprocessing to create the transformation dictionary
- client so that workspace changes can be updated in the transformation dictionary
- definition to transform the found definition line number to the tab line number
- diagnostics to transform the found error line number to the tab line number
- reference to transform the found reference line number to the tab line number

#### To do:
- update lens. (not used at the moment)