### PR TITLE
Play button and sketch output

### DIFF
--- a/client/src/assets/play-arrow.svg
+++ b/client/src/assets/play-arrow.svg
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   width="16"
+   height="16"
+   viewBox="0 0 16 16"
+   fill="#06b831"
+   version="1.1"
+   id="svg4"
+   sodipodi:docname="play-arrow2.svg"
+   inkscape:version="1.1 (c68e22c387, 2021-05-23)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <defs
+     id="defs8" />
+  <sodipodi:namedview
+     id="namedview6"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     showgrid="false"
+     inkscape:zoom="47.0625"
+     inkscape:cx="8"
+     inkscape:cy="8"
+     inkscape:window-width="1920"
+     inkscape:window-height="1017"
+     inkscape:window-x="-8"
+     inkscape:window-y="-8"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg4" />
+  <path
+     d="M4.125 3.02035L12.75 8L4.125 12.9796L4.125 3.02035Z"
+     stroke="#06b831"
+     stroke-width="1.25"
+     id="path2"
+     style="fill:none" />
+</svg>

--- a/client/src/assets/stop-square.svg
+++ b/client/src/assets/stop-square.svg
@@ -1,0 +1,46 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   width="16"
+   height="16"
+   viewBox="0 0 16 16"
+   fill="#06b831"
+   version="1.1"
+   id="svg4"
+   sodipodi:docname="stop-square.svg"
+   inkscape:version="1.1 (c68e22c387, 2021-05-23)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <defs
+     id="defs8" />
+  <sodipodi:namedview
+     id="namedview6"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     showgrid="false"
+     inkscape:zoom="47.0625"
+     inkscape:cx="8"
+     inkscape:cy="8"
+     inkscape:window-width="1920"
+     inkscape:window-height="1017"
+     inkscape:window-x="-8"
+     inkscape:window-y="-8"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg4" />
+  <rect
+     style="fill:none;fill-opacity:0;stroke:#b80606;stroke-width:1.25;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+     id="rect2344"
+     width="8.5947075"
+     height="10.21871"
+     x="3.9526451"
+     y="2.8906465"
+     rx="0"
+     ry="0"
+     inkscape:transform-center-x="-0.15626744"
+     inkscape:transform-center-y="0.069515341" />
+</svg>

--- a/client/src/extension.ts
+++ b/client/src/extension.ts
@@ -1,15 +1,17 @@
 import * as path from 'path';
 import * as vscode from 'vscode';
-const childProcess = require('child_process');
-const fs = require('fs')
 import {
 	LanguageClient,
 	LanguageClientOptions,
 	ServerOptions,
 	TransportKind
 } from 'vscode-languageclient';
+import { SketchRunner } from './sketchRunner';
 
 let client: LanguageClient;
+
+export let clientPath : string
+export let serverPath : string
 
 export function activate(context: vscode.ExtensionContext) {
 	
@@ -43,75 +45,35 @@ export function activate(context: vscode.ExtensionContext) {
 		clientOptions
 	);
 
-	let disposable = vscode.commands.registerCommand('extension.processing', () => {
-		// Running the Sketch entered in Extension Host
-		vscode.window.showInformationMessage(`Running Processing Sketch.!`);
-		try{
+	clientPath = context.asAbsolutePath(path.join('client'))
+	serverPath = context.asAbsolutePath(path.join('server'))
 
-			copyRecursiveSync(`${__dirname.substring(0,__dirname.length-11)}/server/out/compile/`, `${__dirname}/class`)
-			let workDir = `${__dirname.substring(0,__dirname.length-11)}/client/out/class`
-			let corePath = `${__dirname.substring(0,__dirname.length-11)}/server/src/processing/jar/core.jar`
-			let command
-			if (process.platform === 'win32') {
-				command =`java -cp ${corePath}; ProcessingDefault`
-				console.log("Windows environment, using -cp corePath \";\" as command")
-			}
-			else {
-				command = `java -cp ${corePath}: ProcessingDefault`
-				console.log("Linux/Mac environment, using -cp corePath \":\" as command")
-			}
-			childProcess.exec(command, {cwd: workDir})
-			
-		} catch(e) {
-			vscode.window.showInformationMessage(`Error occured while running sketch.!`);
-		}
+	let serverCompilePath = path.join(serverPath, 'out', 'compile')
+	let clientSketchPath = path.join(clientPath, 'out', 'class')
+	let processingCoreFile = path.join(serverPath, 'src', 'processing', 'jar', 'core.jar')
 
-	});
+	const sketchRunner = SketchRunner.getInstance();
+	sketchRunner.initilize(processingCoreFile, clientSketchPath, serverCompilePath)
+
+	let sketchRunnerDisp = vscode.commands.registerCommand("extension.processing.runSketch", () => sketchRunner.runSketch())
+	let sketchStopperDisp = vscode.commands.registerCommand("extension.processing.stopSketch", () => sketchRunner.stopSketch())
 
 	let referenceDisposable = vscode.commands.registerCommand('processing.command.findReferences', (...args: any[]) => {
 		vscode.commands.executeCommand('editor.action.findReferences', vscode.Uri.file(args[0].uri.substring(7,args[0].uri.length)), new vscode.Position(args[0].lineNumber,args[0].column));
 	})
 
-	context.subscriptions.push(disposable);
 	context.subscriptions.push(referenceDisposable)
+	context.subscriptions.push(sketchRunnerDisp)
+	context.subscriptions.push(sketchStopperDisp)
 
 	client.start();
 }
 
-export function deactivate(): Thenable<void> | undefined {
+export async function deactivate(): Promise<void> | undefined {
 	if (!client) {
 		return undefined;
 	}
+	const sketchRunner = SketchRunner.getInstance();
+	await sketchRunner.stopSketch();
 	return client.stop();
 }
-
-/**
- * Look ma, it's cp -R.
- * @param {string} src  The path to the thing to copy.
- * @param {string} dest The path to the new copy.
- */
-
- var copyRecursiveSync = function(src, dest) {
-
-	var exists = fs.existsSync(src);
-	var stats = exists && fs.statSync(src);
-	var isDirectory = exists && stats.isDirectory();
-
-	if (isDirectory) {
-		if(!fs.existsSync(src)) {
-	  		fs.mkdirSync(dest);
-		}
-
-	  fs.readdirSync(src).forEach(function(childItemName) {
-		copyRecursiveSync(path.join(src, childItemName),
-
-						  path.join(dest, childItemName));
-
-	  });
-
-	} else {
-	  fs.copyFileSync(src, dest);
-
-	}
-
-  };

--- a/client/src/sketchRunner.ts
+++ b/client/src/sketchRunner.ts
@@ -1,0 +1,208 @@
+import * as os from "os"
+import { ChildProcess, spawn } from 'child_process';
+import { BufferedOutputChannel } from "./utils/outputBuffer";
+import * as vscode from "vscode";
+
+const fs = require('fs')
+const path = require('path')
+
+/**
+ *  Responable for starting a compiled sketch
+ */
+export class SketchRunner implements vscode.Disposable {
+
+	public static NAME: string = "Processing Sketch"; //Output channel name
+
+	/**
+	 * There should be only one instance of the SketchRunner class to avoid 
+	 * running a sketch multiple times
+	 * 
+	 * @returns Instance of the SketchRunner class
+	 */
+	public static getInstance(): SketchRunner {
+		if (SketchRunner._sketchrunner === null) {
+			SketchRunner._sketchrunner = new SketchRunner();
+		}
+		return SketchRunner._sketchrunner
+	}
+
+	private static _sketchrunner: SketchRunner = null
+	private _child: ChildProcess;
+	private _workDir: string;
+	private _compilePath: string;
+	private _outputChannel: vscode.OutputChannel
+	private _bufferedOutputChannel: BufferedOutputChannel;
+	private _cpArg : string
+
+	/**
+	 * Setup the arguments for the childproces executing the sketch
+	 * 
+	 * @param processingCoreFile Path to the processing core.jar
+	 * @param clientSketchPath Client side path to the compiled version of the sketch
+	 * @param compilePath Server side path to the compiled version of the sketch
+	 */
+	public initilize(processingCoreFile: string, clientSketchPath: string, compilePath: string){
+		this._workDir = clientSketchPath
+		this._compilePath = compilePath
+		this._outputChannel = vscode.window.createOutputChannel(SketchRunner.NAME);
+        this._bufferedOutputChannel = new BufferedOutputChannel(this._outputChannel.append, 300);
+
+		if (process.platform === 'win32') {
+			this._cpArg = `${processingCoreFile};`
+		}	
+		else {
+			this._cpArg = `${processingCoreFile}:`
+		}
+	}
+
+	public get initialized(): boolean {
+        return !!this._outputChannel;
+    }
+
+    public dispose() {
+		if(this.isRunning) {
+			return this.stop()
+		}
+
+        this._outputChannel.dispose();
+        this._bufferedOutputChannel.dispose();
+    }
+
+	private get isRunning(): boolean {
+		return this._child ? true : false;
+	}
+	
+	/**
+	 * Starts a sketch when non is running.
+	 * 
+	 * @returns Has the sketch started
+	 */
+	public async runSketch(): Promise<boolean>{
+		if(this.isRunning) {
+			this.stop();
+			vscode.window.showWarningMessage(`Sketch is already running, stopping sketch.`, )
+			return false
+		}
+
+		try {
+			const result = await this.start();			
+			return result
+		}
+		catch(error) {
+			console.log(error)
+			vscode.window.showErrorMessage(`Error occured while running sketch.!`);
+			return false
+		}
+	}
+
+	/**
+	 * Stops a running sketch.
+	 * 
+	 * @returns Has the sketch stopped
+	 */
+	public async stopSketch(): Promise<boolean> {
+		if(this.isRunning){
+			const result = await this.stop()
+			return result
+		}
+		else {
+			return false
+		}
+	}
+
+	/**
+	 * Executes a copy(comes from the server) of the compiled sketch.
+	 * The output is piped to the outputchannel.
+	 * 
+	 * @returns Exectution state
+	 */
+	private start(): Promise<boolean> {
+		this.copyCompiledSketch(this._compilePath , this._workDir)
+
+		this._bufferedOutputChannel.appendLine(`[Starting] Running processing sketch`);
+		this._outputChannel.show(false)
+		vscode.commands.executeCommand('setContext', 'processing.runningSketch', true)
+
+		if (this.isRunning) {
+			this.stop()
+		}
+
+		return new Promise((resolve, reject) => {
+			this._child = spawn(`java`,
+				["-cp", `${this._cpArg}`, "ProcessingDefault"], {cwd: this._workDir})
+	
+			this._child.on("error", (err) => {
+				reject(err)
+			});
+
+			this._child.on('close', (close) => {
+				this.stop();
+			});
+	
+			this._child.stdout.on("data", (data) => {
+				if (this.isRunning) {
+					this._bufferedOutputChannel.append(data.toString());
+				}
+			});
+			resolve(true);
+		})
+	}
+
+	/**
+	 * Execution of the sketch is stopped. After which the child no longer exists.
+	 * 
+	 * @returns Stopping state
+	 */
+	private stop(): Promise<boolean> {
+		
+		vscode.commands.executeCommand('setContext', 'processing.runningSketch', false)
+
+		return new Promise((resolve, reject) => {
+		  if (!this.isRunning) {
+			resolve(false);
+			return;
+		  }
+		  try {
+			if (this._bufferedOutputChannel) {
+			  this._bufferedOutputChannel.appendLine(`[Done] Stopped the sketch ${os.EOL}`);
+			}
+			this._child.kill();
+			this._child = null;
+			resolve(true);
+		  } catch (error) {
+			  console.log(error)
+			  reject(error);
+		  }
+		  });
+	}
+	
+	/**
+	 * Duplicates .class files from one place to the other.
+	 * 
+	 * @param src Path to the source. Directories are accepted.
+	 * @param dest Path to the desination
+	 */
+	private copyCompiledSketch(src : string, dest : string) {
+
+		var exists = fs.existsSync(src);
+		var stats = exists && fs.statSync(src);
+		var isDirectory = exists && stats.isDirectory();
+		
+		if (isDirectory) {
+			if(!fs.existsSync(dest)) {
+				  fs.mkdirSync(dest);
+			}
+			
+			for (let i = 0; i < fs.readdirSync(src).length; i++) {
+				const contents = fs.readdirSync(src)[i];
+				this.copyCompiledSketch(path.join(src, contents),	path.join(dest, contents));
+			}
+	
+		} else if (path.extname(src) === '.class'){
+			fs.copyFileSync(src, dest);
+	
+		}
+	
+	  };
+	
+}

--- a/client/src/utils/outputBuffer.ts
+++ b/client/src/utils/outputBuffer.ts
@@ -1,0 +1,41 @@
+import { performance } from "perf_hooks";
+import * as vscode from "vscode";
+
+export class BufferedOutputChannel implements vscode.Disposable {
+    private _buffer: string[];
+    private _timer: NodeJS.Timer;
+    private _lastFlushTime: number;
+
+    public constructor(private readonly outputCallback: (value: string) => void, private readonly flushIntervalMs: number) {
+        this._buffer = [];
+        this._timer = setInterval(() => this.tryFlush(), this.flushIntervalMs);
+        this._lastFlushTime = Number.NEGATIVE_INFINITY;
+    }
+
+    public append(value: string) {
+        this.add(value);
+    }
+
+    public appendLine(value: string) {
+        this.add(value + "\n");
+    }
+
+    public dispose() {
+        this.tryFlush();
+        clearInterval(this._timer);
+    }
+
+    private add(value: string) {
+        this._buffer.push(value);
+        this.tryFlush();
+    }
+
+    private tryFlush() {
+        const currentTime = performance.now();
+        if (this._buffer.length > 0 && currentTime - this._lastFlushTime > this.flushIntervalMs) {
+            this.outputCallback(this._buffer.join(""));
+            this._lastFlushTime = currentTime;
+            this._buffer = [];
+        }
+    }
+}

--- a/package.json
+++ b/package.json
@@ -32,10 +32,30 @@
 		],
 		"commands": [
 			{
-				"command": "extension.processing",
-				"title": "Run Processing Sketch"
+				"command": "extension.processing.runSketch",
+				"title": "Run Processing Sketch",
+				"icon" : "./client/src/assets/play-arrow.svg"
+			},
+			{
+				"command": "extension.processing.stopSketch",
+				"title": "Run Processing Sketch",
+				"icon" : "./client/src/assets/stop-square.svg"
 			}
 		],
+		"menus": {
+			"editor/title": [
+				{
+					"command": "extension.processing.runSketch",
+					"group": "navigation",
+					"when": "!processing.runningSketch"
+				},
+				{
+					"command": "extension.processing.stopSketch",
+					"group": "navigation",
+					"when": "processing.runningSketch"
+				}
+			]
+		},
 		"configuration": {
 			"type": "object",
 			"title": "Processing configuration",


### PR DESCRIPTION
#### implements:
An easy way to start and stop the execution of a compiled sketch

#### changes:
- Replaced the existing extension.processing command with a start and stop sketch runner encapsulated in it's own class.
- Added start and stop buttons for executing a sketch
- Piped the output of a running sketch to a dedicated output channel