### PR TITLE
Bugfix/Character range is offset sometimes

### DIFF
--- a/server/src/definition.ts
+++ b/server/src/definition.ts
@@ -22,15 +22,15 @@ export function scheduleLookUpDefinition(receivedUri: string, lineNumber: number
 	parser.tokenArray.forEach(function(token){
 		if(token[1] instanceof ClassDeclarationContext){
 			if(!(javaSpecific.TOP_LEVEL_KEYWORDS.indexOf(token[0].text) > -1)){
-				foundDeclaration[_foundDeclarationCount] = [`class`, token[0].text, token[0].payload._line-(adjustOffset), token[0].payload._charPositionInLine]
+				foundDeclaration[_foundDeclarationCount] = [`class`, token[0].text, token[0].payload._line, token[0].payload._charPositionInLine]
 				_foundDeclarationCount +=1
 			}
 		} else if(token[1] instanceof VariableDeclaratorIdContext){
-			foundDeclaration[_foundDeclarationCount] = [`var`, token[0].text, token[0].payload._line-(adjustOffset), token[0].payload._charPositionInLine]
+			foundDeclaration[_foundDeclarationCount] = [`var`, token[0].text, token[0].payload._line, token[0].payload._charPositionInLine]
 			_foundDeclarationCount +=1
 		} else if(token[1] instanceof MethodDeclarationContext){
 			// TODO: conflict in `_charPositionInLine` due to addition of `public` infront during preprocessing -> tabs should also be handled
-			foundDeclaration[_foundDeclarationCount] = [`method`, token[0].text, token[0].payload._line-(adjustOffset), token[0].payload._charPositionInLine - 3]
+			foundDeclaration[_foundDeclarationCount] = [`method`, token[0].text, token[0].payload._line, token[0].payload._charPositionInLine]
 			_foundDeclarationCount +=1
 		}
 	})
@@ -43,7 +43,7 @@ export function scheduleLookUpDefinition(receivedUri: string, lineNumber: number
 			foundDeclaration.forEach(function(delarationName){
 				if(word[0] == delarationName[1]){
 
-					let lineNumberJavaFile = delarationName[2];
+					let lineNumberJavaFile = delarationName[2]-adjustOffset;
 					let diffLine : number = 0;
 					let docUri : string = '';
 					if (sketch.transformMap.get(lineNumberJavaFile)) {
@@ -52,16 +52,18 @@ export function scheduleLookUpDefinition(receivedUri: string, lineNumber: number
 						docUri = sketch.uri+docName
 					}
 
+					let charOffset = preprocessing.getCharacterOffset(lineNumberJavaFile, delarationName[2])
+
 					finalDefinition = {
 						uri: docUri,
 						range:{
 							start: {
 								line: diffLine-1,
-								character: delarationName[3]
+								character: delarationName[3] - charOffset
 							},
 							end: {
 								line: diffLine-1,
-								character: delarationName[3]+word[0].length
+								character: delarationName[3] + word[0].length - charOffset
 							}
 						}
 					}

--- a/server/src/references.ts
+++ b/server/src/references.ts
@@ -35,16 +35,19 @@ export function scheduleLookUpReference(_referenceParams: ReferenceParams): Loca
 						let docName =  sketch.transformMap.get(lineNumberJavaFile)!.fileName
 						docUri = sketch.uri+docName
 					}
+
+					let charOffset = preprocessing.getCharacterOffset(lineNumberJavaFile, token[0].payload._line)
+
 					multipleTokenOccurenceLocations[_multipleTokenCount] = {
 						uri: docUri,
 						range: {
 							start: {
 								line: refLine-1,
-								character: token[0].payload._charPositionInLine
+								character: token[0].payload._charPositionInLine - charOffset
 							},
 							end: {
 								line: refLine-1,
-								character: token[0].payload._charPositionInLine + word[0].length
+								character: token[0].payload._charPositionInLine + word[0].length - charOffset
 							}
 						}
 					}


### PR DESCRIPTION
Adds a method to calculate the difference in line lengths in the unprocessed- and processed text.

LS-features use this method to offset the symbol position to the correct position

**Affected LS features:**
- Definition
- Reference

Fixes #21